### PR TITLE
Fix invisible colors in boxplot legend

### DIFF
--- a/src/rpg_trajectory_evaluation/plot_utils.py
+++ b/src/rpg_trajectory_evaluation/plot_utils.py
@@ -42,7 +42,7 @@ def boxplot_compare(ax, xlabels,
         # print("Positions: {0}".format(positions))
         bp = ax.boxplot(d, 0, '', positions=positions, widths=widths)
         color_box(bp, data_colors[idx])
-        tmp, = plt.plot([1, 1], c=data_colors[idx], alpha=0)
+        tmp, = plt.plot([1, 1], c=data_colors[idx], alpha=1.0)
         leg_handles.append(tmp)
         leg_labels.append(data_labels[idx])
         idx += 1


### PR DESCRIPTION
I don't think it's in the user's best interest for the color lines in the boxplot legends to be invisible.