### PR TITLE
fix opaque lines in legend

### DIFF
--- a/src/rpg_trajectory_evaluation/plot_utils.py
+++ b/src/rpg_trajectory_evaluation/plot_utils.py
@@ -8,6 +8,7 @@ import yaml
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.lines as mlines
 from mpl_toolkits.mplot3d import Axes3D
 from matplotlib import rc
 rc('font', **{'family': 'serif', 'serif': ['Cardo']})
@@ -42,8 +43,8 @@ def boxplot_compare(ax, xlabels,
         # print("Positions: {0}".format(positions))
         bp = ax.boxplot(d, 0, '', positions=positions, widths=widths)
         color_box(bp, data_colors[idx])
-        tmp, = plt.plot([1, 1], c=data_colors[idx], alpha=0)
-        leg_handles.append(tmp)
+        leg_line = mlines.Line2D([], [], color=data_colors[idx])
+        leg_handles.append(leg_line)
         leg_labels.append(data_labels[idx])
         idx += 1
 


### PR DESCRIPTION
Use mlines instead of drawing an extraneous line. 
The extraneous line was not supposed to be visible, i.e., by setting alpha=0, but this resulted in invisible line style in the legend, which is obviously not what we want.

Note the [pull request](https://github.com/uzh-rpg/rpg_trajectory_evaluation/pull/38) by  @JanOpper also tried to fix this issue.
But that approach will make the extraneous line showing up in the plots.

Also I prefer the original PALLETE (this is the name of variable in the original codebase) instead of the uniformly drawn colors, shown [here](https://github.com/JzHuai0108/rpg_trajectory_evaluation/blob/rpg-vivid-color/scripts/analyze_trajectories.py#L35).
The old palette has colors more vivid to me.